### PR TITLE
cls: store bpw in npz file

### DIFF
--- a/xcell/cls/cl.py
+++ b/xcell/cls/cl.py
@@ -70,6 +70,7 @@ class Cl(ClBase):
         ##################
         self.nl = None
         self.nl_cp = None
+        self.wins = None
 
     def get_NmtBin(self):
         trs = self.data.get_tracers_bare_name_pair(self.tr1, self.tr2)
@@ -128,6 +129,7 @@ class Cl(ClBase):
             mapper1, mapper2 = self.get_mappers()
             f1, f2 = self.get_nmt_fields()
             w = self.get_workspace()
+            wins = w.get_bandpower_windows()
             cl = w.decouple_cell(nmt.compute_coupled_cell(f1, f2))
             if self.tr1 == self.tr2:
                 nl_cp = mapper1.get_nl_coupled()
@@ -135,7 +137,7 @@ class Cl(ClBase):
             else:
                 nl_cp = np.zeros((cl.shape[0], 3 * self.nside))
                 nl = np.zeros_like(cl)
-            np.savez(fname, ell=ell, cl=cl-nl, nl=nl, nl_cp=nl_cp)
+            np.savez(fname, ell=ell, cl=cl-nl, nl=nl, nl_cp=nl_cp, wins=wins)
             self.recompute_cls = False
 
         cl_file = np.load(fname)
@@ -149,6 +151,7 @@ class Cl(ClBase):
         self.cl = cl_file['cl']
         self.nl = cl_file['nl']
         self.nl_cp = cl_file['nl_cp']
+        self.wins = cl_file['wins']
         return cl_file
 
     def get_ell_nl(self):
@@ -172,6 +175,11 @@ class Cl(ClBase):
         m1 = mapper1.mask_name
         m2 = mapper2.mask_name
         return m1, m2
+
+    def get_bandpower_windows(self):
+        if self.ell is None:
+            self.get_cl_file()
+        return self.wins
 
 
 class ClFid(ClBase):

--- a/xcell/cls/to_sacc.py
+++ b/xcell/cls/to_sacc.py
@@ -150,9 +150,6 @@ class sfile():
             cl = ClFid(self.data.data, tr1, tr2)
             ws_bpw = np.zeros((ells_eff.size, ells_nobin.size))
             ws_bpw[np.arange(ells_eff.size), ells_eff.astype(int)] = 1
-        elif not self.use_nl:
-            w = cl.get_workspace()
-            ws_bpw = w.get_bandpower_windows()
 
         cl.get_cl_file()
 
@@ -168,7 +165,7 @@ class sfile():
                 cli = ws_bpw.dot(cl.cl[i])
                 wins = sacc.BandpowerWindow(ells_nobin, ws_bpw.T)
             else:
-                wins = sacc.BandpowerWindow(ells_nobin, ws_bpw[i, :, i, :].T)
+                wins = sacc.BandpowerWindow(ells_nobin, cl.wins[i, :, i, :].T)
                 cli = cl.cl[i]
 
             self.s.add_ell_cl(cl_type, tr1, tr2, ells_eff, cli, window=wins)

--- a/xcell/tests/test_cls.py
+++ b/xcell/tests/test_cls.py
@@ -103,6 +103,7 @@ def test_get_ell_cl():
     sigma = np.sqrt(np.diag(cov))
 
     assert np.all(np.fabs(cl_m1 - cl) < 5 * sigma)
+    assert np.all(cl_class.wins == w.get_bandpower_windows())
 
 
 def test_get_covariance():


### PR DESCRIPTION
Store bandpower window functions in the npz files together with the cl's. This allows to build the sacc files without reading the workspace.